### PR TITLE
Add script to generate pandas dataframe form work values

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,6 @@ We'd also like to archive the `positions.xtc` onto S3 so we can retrieve all the
 The work values can go into an entry in a table, and then used to compute a free energy estimate for that transformation.
 
 Hannah then uses a [maximum likelihood estimator](https://pubs.acs.org/doi/abs/10.1021/acs.jcim.9b00528) to compute the free energy of that particular ligand (in another table) using the known experimental measured free energies of given ligands and the relative estimated binding free energies among ligands from the transformations table
+
+We also want to extract a snapshot of the ligand B complex form `positions.xtc` (the last snapshot) from each of the result WUs so we can present the chemists with a visual picture of what the protein:ligand interactions might look like.
+There's a way to extract a PDB file (a text file) from the last snapshot with a script (using [MDTraj](http://mdtraj.org)) or a command-line tool. These PDB files could be stored as single file objects on S3 and retrieved via a URL when needed.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
 # PersesAtFoldingAtHome
+
+
+## Documentation of pipeline:
+
+See all the [details of running a FAH server and setting up new projects first](https://github.com/foldingathome/fah-docs/wiki).
+
+- [ ] First, the project manager sets up one or more protein PDB files and ligand SDF files
+- [ ] We select a FAH complex project ID (`complex_projid`) and solvent project ID (`solvent_projid`) pair from the [reserved set of projects wiki](https://github.com/FoldingAtHome/fah-docs/wiki/Project-numbers). FAH is limited to 65536 projects over its entire lifetime, so we have to conserve project numbers when possible. The complex project will have a large number of total atoms (~80K) and the solvent project will have a small number (~4K) where we can keep adding `RUN`s for new systems or new transformations as long as they fit in the simulation boxes.
+- [ ] When we want to add one or more new ligands to the set (e.g. by adding rows to the [COVID Moonshot Compound Tracker](https://covid.postera.ai/covid/submissions/compounds), which can be [downloaded via the "Export CSV" button](https://covid.postera.ai/covid/submissions.csv) or at the associated [master GitHub repo](https://github.com/postera-ai/COVID_moonshot_submissions) in a [CSV file](https://github.com/postera-ai/COVID_moonshot_submissions/blob/master/covid_submissions_all_info.csv)), we convert the SMILES for the ligand into actual 3D molecules, expanding stereochemistry and store in SDF, and then identify which reference protein PDB structures we will create alchemical transformations (one transformation per FAH `RUN` for).  [JDC will provide script for this part, still being worked out.]
+Hannah currently uses a [script](https://github.com/choderalab/PersesAtFoldingAtHome/blob/master/SARS-CoV-2-Mpro/create-json.py) to populate a [JSON file](https://github.com/choderalab/PersesAtFoldingAtHome/blob/master/SARS-CoV-2-Mpro/aminopyridines%202020-07-04.json), but we don't need to use this format (unless Hannah says otherwise).
+- [ ] Hannah uses a script to parallelize the setup of individual transformations in parallel using our cluster (`lilac`) via an [LSF bash script](https://github.com/choderalab/PersesAtFoldingAtHome/blob/master/SARS-CoV-2-Mpro/submit-ligpairs.sh) and a [python `run.py`](https://github.com/choderalab/PersesAtFoldingAtHome/blob/master/SARS-CoV-2-Mpro/run.py).
+- [ ] To set up a single ligand transformation (`i -> j`), we run the `perses` command-line entry point `perses-fah config.yaml`, where `config.yaml` looks like this:
+```yaml
+protein_pdb: CDK2_protein.pdb
+ligand_file: CDK2_ligands_shifted.sdf
+old_ligand_index: 0
+new_ligand_index: 1
+forcefield_files:
+    - amber/ff14SB.xml # ff14SB protein force field
+    - amber/tip3p_standard.xml # TIP3P and recommended monovalent ion parameters
+    - amber/tip3p_HFE_multivalent.xml # for divalent ions
+    - amber/phosaa10.xml # HANDLES THE TPO
+atom_expression:
+    - IntType
+bond_expression:
+    - DefaultBonds
+complex_projid: 13418
+solvent_projid: 13419
+```
+In practice, this is generated from a JSON file with a script called `run.py`.
+This requires a GPU to be practical (e.g. GTX 1080).
+
+This will create files `{complex_projid}/RUNS/RUN/...` and `{solvent_projid}/RUNS/RUN/...` with the directories populated with some metadata important to retain plus `{system,state,integrator,core}.xml` (or `.bz2` or `.gz` compressed versions thereof).
+- [ ] `rsync` these files over to `server@aws3.foldingathome.org:/projects/available/covid-moonshot/`. It's OK to add more RUNs dynamically, but they must be compact and sequentially numbered from `RUN0`. The `{projid}` directory will be symlinked to `/home/server/server2/projects/{projid}` for the server to discover it.
+- [ ] The `{projid}` directory will contain a `project.xml` file that looks like this:
+```XML
+<project type="OPENMM_22" id="13418">
+  <gpu/>
+  <min-core-version v="0.0.11"/>
+
+  <job-priority v="queue-count gen clone run"/>
+
+  <runs v="759"/>
+  <clones v="100"/>
+  <gens v="6"/>
+  <atoms v="89709"/>
+
+  <timeout v="1.0"/>
+  <deadline v="2.0"/>
+  <!-- <k-factor v="0.75"/> -->
+  <!-- <stats-credit v="53245"/> -->  
+  <!-- <stats-credit v="70000"/> --> <!-- SARS-CoV-2 Mpro -->
+  <stats-credit v="55000"/>
+
+  <send>
+    $home/core.xml
+    $home/RUNS/RUN$run/system.xml.bz2
+    $home/RUNS/RUN$run/integrator.xml
+    state.xml.bz2
+  </send>
+
+  <create-command>
+    ln -s -f $home/RUNS/RUN$run/state.xml.bz2 $jobdir/state.xml.bz2
+  </create-command>
+
+  <next-gen-command>
+    mv -f $results/checkpointState.xml.bz2 $jobdir/state.xml.bz2
+  </next-gen-command>
+
+  <!-- Don't copy to S3 storage gateway -->
+  <archive-command>
+    /usr/bin/true
+  </archive-command>
+
+</project>
+```
+- [ ] edit `{projid}/project.xml` for each project and increment the `runs` tag value to reflect the new runs
+- [ ] restart the FAH server with `sudo service fah-work restart` as the `server` user on `aws3.foldingathome.org`, and check `~/server2/log.txt` that the server successfully restarts
+- [ ] if this is a new project, some manual benchmarking and assignment server stuff needs to be done: see [here](https://github.com/FoldingAtHome/fah-docs/wiki/Set-up-an-OpenMM-%28GPU%29-Project) and subsequent steps. We'll assume we're just adding new RUNs to an existing project.
+- [ ] Data ends up in
+```
+/home/server/server2/data/SVR314342810/PROJ13418
+/home/server/server2/data/SVR314342810/PROJ13419
+```
+with a structure of
+```
+/home/server/server2/data/SVR314342810/PROJ13418/RUN*/CLONE*/results*/
+```
+- [ ] Each returned WU will contain `results#` directory that looks like this for `(PROJ13418,RUN0,CLONE0,GEN0)`:
+```
+$ ls -ltr /home/server/server2/data/SVR314342810/PROJ13418/RUN0/CLONE0/results0
+total 136
+-rw-r--r-- 1 fah-work fah-work  7404 Jul 17 12:00 logfile_01.txt
+-rw-r--r-- 1 fah-work fah-work 13851 Jul 17 12:00 science.log
+-rw-r--r-- 1 fah-work fah-work 97596 Jul 17 12:00 positions.xtc
+-rw-r--r-- 1 fah-work fah-work 13813 Jul 17 12:00 globals.csv
+```
+The `globals.csv` file contains the `protocol_work` we want to extract and store.
+
+We currently do this using the [`consolidate-work.py`](https://github.com/choderalab/PersesAtFoldingAtHome/blob/add-analysis-script/consolidate-work.py) script to extract two unitless work values (implicitly in units of kT): `forward_work` and `reverse_work`.
+
+We'd also like to archive the `positions.xtc` onto S3 so we can retrieve all the positions associated with individual `(PROJ,RUN,CLONE,GEN)` tuples as desired for further debugging or viewing.
+
+The work values can go into an entry in a table, and then used to compute a free energy estimate for that transformation.
+
+Hannah then uses a [maximum likelihood estimator](https://pubs.acs.org/doi/abs/10.1021/acs.jcim.9b00528) to compute the free energy of that particular ligand (in another table) using the known experimental measured free energies of given ligands and the relative estimated binding free energies among ligands from the transformations table

--- a/SARS-CoV-2-Mpro/README.md
+++ b/SARS-CoV-2-Mpro/README.md
@@ -10,7 +10,7 @@ Docking:
 * `run-lsf-aggregate.sh` - aggregate docking results
 * `aminopyridines_for_chodera_lab-docked.csv` - docked compound scores and data from original CSV
 * `aminopyridines_for_chodera_lab-docked.sdf` - docked compound geometries in appropriate protonation states
-* `aminopyridines_for_chodera_lab-docked.pdb` - PDB file of SDF 
+* `aminopyridines_for_chodera_lab-docked.pdb` - PDB file of SDF
 * `aminopyridines_for_chodera_lab-docked/` - docked compounds prior to aggregation
 * `aminopyridines_for_chodera_lab-docked-justscore.csv` - just the scores
 
@@ -21,3 +21,6 @@ Setup:
 * `submit-ligpairs.sh` - LSF batch queue script to launch automated setup
 * `run.py` - script executed by batch queue script
 * `receptors/` - source structures from https://github.com/FoldingAtHome/covid-moonshot/tree/master/receptors
+
+Analysis:
+* `consolidate-work-to-pandas.py` : script that scrapes PROJ directories on FAH server to create pandas dataframe of protocol work for analysis of binding free eneriges

--- a/SARS-CoV-2-Mpro/consolidate-work-to-pandas.py
+++ b/SARS-CoV-2-Mpro/consolidate-work-to-pandas.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+
+"""
+Extract final work values to a single pandas dataframe
+"""
+
+import os
+
+projects = {
+    'complex' : 13418,
+    'solvent' : 13419,
+    }
+
+NUM_EXPECTED_WORK = 4001
+NUM_EXPECTED_WORK = 401
+NUM_EXPECTED_WORK = 41
+
+phases = list(projects.keys())
+
+basepaths = [
+    '/home/server/server2/data/SVR314342810/',
+    ]
+
+import datetime
+timestamp = datetime.datetime.now()
+
+def get_results(PROJ):
+    """
+    Get all result directories for a given project
+
+    Parameters
+    ----------
+    PROJ : str
+        PROJ, such as 'PROJ13400'
+
+    Returns
+    -------
+    results : dict
+        results[path] = (PROJ,RUN,CLONE,GEN) where path is the results directory
+    """
+    from tqdm import tqdm
+    
+    # Make a list of all results packets paths from all locations
+    paths = list()
+    from glob import glob # glob takes forever on S3 file gateway, so we don't use it
+    import os
+    import re
+    for basepath in basepaths:
+        #paths += glob(f'{basepath}/{PROJ}/RUN*/CLONE*/results*')
+        print(basepath)
+        for RUN in tqdm(os.listdir(f'{basepath}/{PROJ}')):
+            if not re.search('RUN', RUN): continue
+            for CLONE in os.listdir(f'{basepath}/{PROJ}/{RUN}'):
+                if not re.search('CLONE', CLONE): continue
+                for result in os.listdir(f'{basepath}/{PROJ}/{RUN}/{CLONE}'):
+                    if re.search('results\d+$', result):
+                        path = f'{basepath}/{PROJ}/{RUN}/{CLONE}/{result}'
+                        paths.append(path)
+
+    # Construct results
+    results = dict()
+    nfailures = 0
+    nsuccesses = 0
+    for path in tqdm(paths):
+        match = re.search('(?P<RUN>RUN\d+)/(?P<CLONE>CLONE\d+)/results(?P<GEN>\d+)$', path)
+
+        # Skip failures
+        if match is None:
+            nfailures += 1
+            continue
+        nsuccesses += 1
+        
+        RUN = match.group('RUN')
+        CLONE = match.group('CLONE')
+        GEN = f"{match.group('GEN')}"
+
+        results[path] = (PROJ,RUN,CLONE,GEN)
+
+    failure_rate = float(nfailures) / float(nfailures + nsuccesses)
+    print(f'{PROJ} : {nsuccesses} successes, {nfailures} failures ({failure_rate*100:.3}% failure rate)')
+        
+    return results
+            
+# Get all results directories
+print('Gathering all results packets...')
+results = dict()
+for phase in phases:
+    PROJ = f'PROJ{projects[phase]}'
+    print(PROJ)
+    results.update(get_results(PROJ))
+            
+def get_work(path):
+    import pandas as pd
+    import os
+    import numpy as np
+    import re
+    
+    match = re.search('(?P<PROJ>PROJ\d+)/(?P<RUN>RUN\d+)/(?P<CLONE>CLONE\d+)/results(?P<GEN>\d+)$', path)
+    PROJ = match.group('PROJ')
+    RUN = match.group('RUN')
+    CLONE = match.group('CLONE')
+    GEN = f"GEN{match.group('GEN')}"
+
+    # Read csvfile
+    try:
+        csvfile = os.path.join(path, 'globals.csv')
+        # Read the CSV file contents
+        with open(csvfile, 'rt') as infile:
+            lines = infile.readlines()
+        # Keep track of the last header line
+        header_line_number = 0
+        for line_number, line in enumerate(lines):
+            if 'kT' in line:
+                header_line_number = line_number
+        # Create pandas data frame
+        with open(csvfile, 'rt') as infile:
+            df = pd.read_csv(infile, header=header_line_number)
+        # Drop duplicates
+        df.drop_duplicates(inplace=True)
+        # Correct work values
+        kT = df['kT'].to_numpy(dtype=np.float32)[0]
+        df['protocol_work'] /= kT
+        df['Enew'] /= kT
+        # Filter columns
+        df = df[['Step', 'Time','lambda', 'Enew', 'protocol_work']]        
+        # Perform sanity checks
+        # TODO: Determine length automatically from first example
+        protocol_work = df['protocol_work'].to_numpy()
+        assert len(protocol_work) == NUM_EXPECTED_WORK, f'Expected {NUM_EXPECTED_WORK} work values, found {len(protocol_work)} : {path}'
+        # Check total number of steps
+        step = df['Step'].to_numpy()
+        nsteps = step[-1] - step[0]
+        NSTEPS_EXPECTED = 1000000
+        assert nsteps == NSTEPS_EXPECTED, f'Expected {NSTEPS_EXPECTED} steps, found {nsteps} : {path}'
+        # Return the dataframe
+        return (PROJ, RUN, CLONE, GEN, df)
+    except Exception as e:
+        print(f'Exception for {csvfile}:', e)
+        return None
+
+# Process all paths
+from multiprocessing import Pool
+pool = Pool(processes=8)
+print('Reading all work trajectories...')
+import pandas as pd
+from tqdm import tqdm
+import numpy as np
+
+CHECKPOINT_FREQUENCY = 10000
+
+npaths = len(results)
+master_df = pd.DataFrame(index=np.arange(0, npaths), columns=['PROJ', 'RUN', 'CLONE', 'GEN', 'forward_work', 'reverse_work', 'forward_final_potential', 'reverse_final_potential'])
+results_processed = 0
+for result in tqdm(pool.imap_unordered(get_work, results), total=len(results)):
+    if result is not None:
+        # Process result
+        PROJ, RUN, CLONE, GEN, df = result
+        protocol_work = df['protocol_work'].to_numpy()
+        Enew = df['Enew'].to_numpy()
+        forward_work = protocol_work[20] - protocol_work[10]
+        reverse_work = protocol_work[40] - protocol_work[30]
+        forward_final_potential = Enew[20]
+        reverse_final_potential = Enew[40]
+        # Add row to dataframe
+        row = [PROJ, RUN, CLONE, GEN, forward_work, reverse_work, forward_final_potential, reverse_final_potential]
+        master_df.loc[results_processed] = row
+        # Increment counter
+        results_processed += 1
+        # Checkpoint periodically
+        #if results_processed % CHECKPOINT_FREQUENCY == 0:
+        #    master_df.to_pickle('work.pkl.bz2')
+
+master_df.to_pickle('work-13418.pkl.bz2')


### PR DESCRIPTION
This PR adds a version of the script that scrapes the work values from `globals.csv` files produced during each completed work unit (WU) from the Folding@Home server and builds a single pandas dataframe.

We'll eventually want to make this much more clever, such as
* Don't build the whole dataframe from scratch, since this takes forever---only look at things we haven't already read
* Put the data into a database that lives in the cloud instead of a dataframe?
* Use a command-line thing run by the server when each WU is received to analyze `globals.csv` and push data into the cloud instead, or perhaps an AWS lambda function?

cc @mcwitt 